### PR TITLE
[Week3] 3주차 과제

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -42,21 +44,29 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.kotlinx.immutable)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    dependencies {
+        // AndroidX Core & Lifecycle
+        implementation(libs.bundles.androidx.core)
+
+        // Compose
+        implementation(platform(libs.androidx.compose.bom))
+        implementation(libs.bundles.compose)
+        debugImplementation(libs.bundles.compose.debug)
+
+        // Navigation (SAA 적용)
+        implementation(libs.androidx.navigation.compose)
+
+        // Kotlinx
+        implementation(libs.kotlinx.immutable)
+        implementation(libs.kotlinx.serialization.json)
+
+        // Room
+        implementation(libs.bundles.room)
+        ksp(libs.androidx.room.compiler)
+
+        // Test
+        testImplementation(libs.junit)
+        androidTestImplementation(platform(libs.androidx.compose.bom))
+        androidTestImplementation(libs.bundles.androidTest)
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,19 +13,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.LETSSOPT">
         <activity
-            android:name=".presentation.signup.SignUpActivity"
-            android:exported="false"
-            android:label="@string/title_activity_sign_up"
-            android:theme="@style/Theme.LETSSOPT" />
-        <activity
             android:name=".presentation.main.MainActivity"
-            android:exported="false"
-            android:label="@string/title_activity_main"
-            android:theme="@style/Theme.LETSSOPT" />
-        <activity
-            android:name=".presentation.signin.SignInActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.LETSSOPT">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/letssopt/LETSSOPTApplication.kt
+++ b/app/src/main/java/com/example/letssopt/LETSSOPTApplication.kt
@@ -1,4 +1,4 @@
-package com.example.letssopt.presentation
+package com.example.letssopt
 
 import android.app.Application
 import com.example.letssopt.core.data.AuthPreference

--- a/app/src/main/java/com/example/letssopt/core/data/LibraryDao.kt
+++ b/app/src/main/java/com/example/letssopt/core/data/LibraryDao.kt
@@ -1,7 +1,6 @@
 package com.example.letssopt.core.data
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -18,6 +17,6 @@ interface LibraryDao {
     @Query("SELECT * FROM library_table")
     fun getAllItems(): Flow<List<LibraryEntity>>
 
-    @Delete
-    suspend fun delete(libraryEntity: LibraryEntity)
+    @Query("DELETE FROM library_table WHERE id = :id")
+    suspend fun deleteById(id: Long)
 }

--- a/app/src/main/java/com/example/letssopt/core/data/LibraryDao.kt
+++ b/app/src/main/java/com/example/letssopt/core/data/LibraryDao.kt
@@ -1,0 +1,23 @@
+package com.example.letssopt.core.data
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface LibraryDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: LibraryEntity)
+
+    @Query("SELECT * FROM library_table WHERE id = :id")
+    suspend fun getItemById(id: Long): LibraryEntity?
+
+    @Query("SELECT * FROM library_table")
+    fun getAllItems(): Flow<List<LibraryEntity>>
+
+    @Delete
+    suspend fun delete(libraryEntity: LibraryEntity)
+}

--- a/app/src/main/java/com/example/letssopt/core/data/LibraryDatabase.kt
+++ b/app/src/main/java/com/example/letssopt/core/data/LibraryDatabase.kt
@@ -1,0 +1,28 @@
+package com.example.letssopt.core.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [LibraryEntity::class], version = 1, exportSchema = false)
+abstract class LibraryDatabase : RoomDatabase() {
+    abstract fun libraryDao(): LibraryDao
+
+    companion object {
+        @Volatile
+        private var Instance: LibraryDatabase? = null
+
+        fun getDatabase(context: Context): LibraryDatabase {
+            return Instance ?: synchronized(this) {
+                Room.databaseBuilder(
+                    context.applicationContext,
+                    LibraryDatabase::class.java,
+                    "library_database"
+                ).fallbackToDestructiveMigration()
+                    .build()
+                    .also { Instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/letssopt/core/data/LibraryEntity.kt
+++ b/app/src/main/java/com/example/letssopt/core/data/LibraryEntity.kt
@@ -1,0 +1,15 @@
+package com.example.letssopt.core.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "library_table")
+data class LibraryEntity(
+    @PrimaryKey
+    val id: Long,
+    @ColumnInfo(name = "image_res")
+    val imageRes: Int,
+    @ColumnInfo(name = "title")
+    val title: String
+)

--- a/app/src/main/java/com/example/letssopt/core/designsystem/component/SoptContentItem.kt
+++ b/app/src/main/java/com/example/letssopt/core/designsystem/component/SoptContentItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -24,7 +23,6 @@ fun SoptContentItem(
 ) {
     Box(
         modifier = modifier
-            .width(100.dp)
             .aspectRatio(2f / 3f)
             .clip(RoundedCornerShape(10.dp))
     ) {

--- a/app/src/main/java/com/example/letssopt/core/navigation/MainTabRoute.kt
+++ b/app/src/main/java/com/example/letssopt/core/navigation/MainTabRoute.kt
@@ -1,0 +1,3 @@
+package com.example.letssopt.core.navigation
+
+interface MainTabRoute : Route

--- a/app/src/main/java/com/example/letssopt/core/navigation/Route.kt
+++ b/app/src/main/java/com/example/letssopt/core/navigation/Route.kt
@@ -1,0 +1,3 @@
+package com.example.letssopt.core.navigation
+
+interface Route

--- a/app/src/main/java/com/example/letssopt/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/HomeScreen.kt
@@ -26,6 +26,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun HomeRoute(
     paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
     viewModel: HomeViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -37,7 +38,7 @@ fun HomeRoute(
 }
 
 @Composable
-fun HomeScreen(
+private fun HomeScreen(
     paddingValues: PaddingValues,
     uiState: HomeUiState
 ) {

--- a/app/src/main/java/com/example/letssopt/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/HomeScreen.kt
@@ -21,7 +21,6 @@ import com.example.letssopt.presentation.home.component.banner.HomeBannerSection
 import com.example.letssopt.presentation.home.component.content.HomeContentSection
 import com.example.letssopt.presentation.home.component.party.HomePartySection
 import com.example.letssopt.presentation.home.state.HomeUiState
-import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun HomeRoute(
@@ -97,10 +96,10 @@ private fun HomeScreenPreview() {
         HomeScreen(
             paddingValues = PaddingValues(0.dp),
             uiState = HomeUiState(
-                bannerList = HomeUiState.dummyBannerList.toImmutableList(),
-                hotList = HomeUiState.dummyContentList.toImmutableList(),
-                upcomingList = HomeUiState.dummyContentList.toImmutableList(),
-                partyList = HomeUiState.dummyPartyList.toImmutableList()
+                bannerList = HomeUiState.dummyBannerList,
+                hotList = HomeUiState.dummyContentList,
+                upcomingList = HomeUiState.dummyContentList,
+                partyList = HomeUiState.dummyPartyList
             )
         )
     }

--- a/app/src/main/java/com/example/letssopt/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/HomeViewModel.kt
@@ -2,17 +2,16 @@ package com.example.letssopt.presentation.home
 
 import androidx.lifecycle.ViewModel
 import com.example.letssopt.presentation.home.state.HomeUiState
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class HomeViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(
         HomeUiState(
-            bannerList = HomeUiState.dummyBannerList.toImmutableList(),
-            hotList = HomeUiState.dummyContentList.toImmutableList(),
-            upcomingList = HomeUiState.dummyContentList.toImmutableList(),
-            partyList = HomeUiState.dummyPartyList.toImmutableList()
+            bannerList = HomeUiState.dummyBannerList,
+            hotList = HomeUiState.dummyContentList,
+            upcomingList = HomeUiState.dummyContentList,
+            partyList = HomeUiState.dummyPartyList
         )
     )
     val uiState = _uiState.asStateFlow()

--- a/app/src/main/java/com/example/letssopt/presentation/home/component/party/HomePartyItem.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/component/party/HomePartyItem.kt
@@ -24,11 +24,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.letssopt.R
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
-import com.example.letssopt.presentation.home.model.PartyUiModel
+import com.example.letssopt.presentation.home.model.HomePartyUiModel
 
 @Composable
 fun HomePartyItem(
-    item: PartyUiModel,
+    item: HomePartyUiModel,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.width(196.dp)) {
@@ -86,7 +86,7 @@ fun HomePartyItem(
 private fun HomePartyItemPreview() {
     LETSSOPTTheme {
         HomePartyItem(
-            item = PartyUiModel(
+            item = HomePartyUiModel(
                 imageRes = R.drawable.img_party,
                 startTime = "오늘 21:13에 시작",
                 tag = "# 왕과 사는 남자"

--- a/app/src/main/java/com/example/letssopt/presentation/home/component/party/HomePartySection.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/component/party/HomePartySection.kt
@@ -14,13 +14,13 @@ import androidx.compose.ui.unit.dp
 import com.example.letssopt.R
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
 import com.example.letssopt.presentation.home.component.HomeSectionHeader
-import com.example.letssopt.presentation.home.model.PartyUiModel
+import com.example.letssopt.presentation.home.model.HomePartyUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun HomePartySection(
-    partyList: ImmutableList<PartyUiModel>,
+    partyList: ImmutableList<HomePartyUiModel>,
     modifier: Modifier = Modifier,
     showMore: Boolean = false,
     onMoreClick: () -> Unit = {}
@@ -56,7 +56,7 @@ private fun HomePartySectionPreview() {
     LETSSOPTTheme {
         HomePartySection(
             partyList = listOf(
-                PartyUiModel(
+                HomePartyUiModel(
                     imageRes = R.drawable.img_party,
                     startTime = "오늘 21:13에 시작",
                     tag = "# 왕과 사는 남자"

--- a/app/src/main/java/com/example/letssopt/presentation/home/model/HomePartyUiModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/model/HomePartyUiModel.kt
@@ -4,7 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Immutable
 
 @Immutable
-data class PartyUiModel(
+data class HomePartyUiModel(
     @param:DrawableRes val imageRes: Int,
     val startTime: String,
     val tag: String

--- a/app/src/main/java/com/example/letssopt/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/navigation/HomeNavigation.kt
@@ -1,0 +1,32 @@
+package com.example.letssopt.presentation.home.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.example.letssopt.core.navigation.MainTabRoute
+import com.example.letssopt.presentation.home.HomeRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigateHome(
+    navOptions: NavOptions? = null
+) {
+    navigate(Home, navOptions)
+}
+
+fun NavGraphBuilder.homeGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
+) {
+    composable<Home> {
+        HomeRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp
+        )
+    }
+}
+
+
+@Serializable
+data object Home: MainTabRoute

--- a/app/src/main/java/com/example/letssopt/presentation/home/state/HomeContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/state/HomeContract.kt
@@ -2,7 +2,7 @@ package com.example.letssopt.presentation.home.state
 
 import androidx.compose.runtime.Immutable
 import com.example.letssopt.R
-import com.example.letssopt.presentation.home.model.PartyUiModel
+import com.example.letssopt.presentation.home.model.HomePartyUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -12,7 +12,7 @@ data class HomeUiState(
     val bannerList: ImmutableList<Int> = persistentListOf(),
     val hotList: ImmutableList<Int> = persistentListOf(),
     val upcomingList: ImmutableList<Int> = persistentListOf(),
-    val partyList: ImmutableList<PartyUiModel> = persistentListOf()
+    val partyList: ImmutableList<HomePartyUiModel> = persistentListOf()
 ) {
     companion object {
         val dummyBannerList = listOf(
@@ -29,10 +29,10 @@ data class HomeUiState(
             R.drawable.img_content3,
         ).toImmutableList()
         val dummyPartyList = listOf(
-            PartyUiModel(R.drawable.img_party, "오늘 21:13에 시작", "# 왕과 사는 남자"),
-            PartyUiModel(R.drawable.img_party, "오늘 22:22에 시작", "# 파묘"),
-            PartyUiModel(R.drawable.img_party, "오늘 21:13에 시작", "# 왕과 사는 남자"),
-            PartyUiModel(R.drawable.img_party, "오늘 22:22에 시작", "# 파묘"),
+            HomePartyUiModel(R.drawable.img_party, "오늘 21:13에 시작", "# 왕과 사는 남자"),
+            HomePartyUiModel(R.drawable.img_party, "오늘 22:22에 시작", "# 파묘"),
+            HomePartyUiModel(R.drawable.img_party, "오늘 21:13에 시작", "# 왕과 사는 남자"),
+            HomePartyUiModel(R.drawable.img_party, "오늘 22:22에 시작", "# 파묘"),
         ).toImmutableList()
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/home/state/HomeContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/home/state/HomeContract.kt
@@ -5,6 +5,7 @@ import com.example.letssopt.R
 import com.example.letssopt.presentation.home.model.PartyUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Immutable
 data class HomeUiState(
@@ -18,7 +19,7 @@ data class HomeUiState(
             R.drawable.img_banner,
             R.drawable.img_content1,
             R.drawable.img_content2,
-        )
+        ).toImmutableList()
         val dummyContentList = listOf(
             R.drawable.img_content1,
             R.drawable.img_content2,
@@ -26,12 +27,12 @@ data class HomeUiState(
             R.drawable.img_content1,
             R.drawable.img_content2,
             R.drawable.img_content3,
-        )
+        ).toImmutableList()
         val dummyPartyList = listOf(
             PartyUiModel(R.drawable.img_party, "오늘 21:13에 시작", "# 왕과 사는 남자"),
             PartyUiModel(R.drawable.img_party, "오늘 22:22에 시작", "# 파묘"),
             PartyUiModel(R.drawable.img_party, "오늘 21:13에 시작", "# 왕과 사는 남자"),
             PartyUiModel(R.drawable.img_party, "오늘 22:22에 시작", "# 파묘"),
-        )
+        ).toImmutableList()
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
@@ -23,6 +23,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun LibraryRoute(
     paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
     viewModel: LibraryViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -35,7 +36,7 @@ fun LibraryRoute(
 }
 
 @Composable
-fun LibraryScreen(
+private fun LibraryScreen(
     paddingValues: PaddingValues,
     uiState: LibraryUiState,
     onDeleteClick: (Int) -> Unit

--- a/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
@@ -1,5 +1,6 @@
 package com.example.letssopt.presentation.library
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -8,25 +9,47 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.letssopt.core.data.LibraryDatabase
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
 import com.example.letssopt.presentation.library.component.LibraryEmptyView
 import com.example.letssopt.presentation.library.component.LibraryVerticalGrid
+import com.example.letssopt.presentation.library.state.LibrarySideEffect
 import com.example.letssopt.presentation.library.state.LibraryUiState
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun LibraryRoute(
     paddingValues: PaddingValues,
-    navigateUp: () -> Unit,
-    viewModel: LibraryViewModel = viewModel()
+    navigateUp: () -> Unit
 ) {
+    val context = LocalContext.current
+    val database = remember { LibraryDatabase.getDatabase(context) }
+
+    val viewModel: LibraryViewModel = viewModel {
+        LibraryViewModel(database.libraryDao())
+    }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collectLatest { effect ->
+            when (effect) {
+                is LibrarySideEffect.ShowToast -> {
+                    Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
 
     LibraryScreen(
         paddingValues = paddingValues,
@@ -39,7 +62,7 @@ fun LibraryRoute(
 private fun LibraryScreen(
     paddingValues: PaddingValues,
     uiState: LibraryUiState,
-    onDeleteClick: (Int) -> Unit
+    onDeleteClick: (Long) -> Unit
 ) {
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
@@ -40,7 +40,7 @@ fun LibraryRoute(
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(viewModel.sideEffect) {
+    LaunchedEffect(viewModel) {
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
                 is LibrarySideEffect.ShowToast -> {

--- a/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/LibraryScreen.kt
@@ -24,7 +24,6 @@ import com.example.letssopt.presentation.library.component.LibraryEmptyView
 import com.example.letssopt.presentation.library.component.LibraryVerticalGrid
 import com.example.letssopt.presentation.library.state.LibrarySideEffect
 import com.example.letssopt.presentation.library.state.LibraryUiState
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -97,7 +96,7 @@ private fun LibraryScreenPreview() {
         LibraryScreen(
             paddingValues = PaddingValues(0.dp),
             uiState = LibraryUiState(
-                items = LibraryUiState.dummyItems.toImmutableList()
+                items = LibraryUiState.dummyItems
             ),
             onDeleteClick = {}
         )

--- a/app/src/main/java/com/example/letssopt/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/LibraryViewModel.kt
@@ -1,25 +1,47 @@
 package com.example.letssopt.presentation.library
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.letssopt.core.data.LibraryDao
+import com.example.letssopt.presentation.library.model.LibraryUiModel
+import com.example.letssopt.presentation.library.state.LibrarySideEffect
 import com.example.letssopt.presentation.library.state.LibraryUiState
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
-class LibraryViewModel : ViewModel() {
-    private val _uiState = MutableStateFlow(
-        LibraryUiState(
-            items = LibraryUiState.dummyItems.toImmutableList()
-        )
-    )
-    val uiState = _uiState.asStateFlow()
+class LibraryViewModel(
+    private val libraryDao: LibraryDao
+) : ViewModel() {
+    private val _sideEffect = MutableSharedFlow<LibrarySideEffect>()
+    val sideEffect: SharedFlow<LibrarySideEffect> = _sideEffect.asSharedFlow()
 
-    fun deleteItem(id: Int) {
-        _uiState.update { current ->
-            current.copy(
-                items = current.items.filter { it.id != id }.toImmutableList()
+    val uiState = libraryDao.getAllItems()
+        .map { entities ->
+            LibraryUiState(
+                items = entities.map { entity ->
+                    LibraryUiModel(
+                        id = entity.id,
+                        imageRes = entity.imageRes,
+                        title = entity.title
+                    )
+                }.toImmutableList()
             )
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LibraryUiState())
+
+
+
+    fun deleteItem(id: Long) {
+        viewModelScope.launch {
+            val entity = libraryDao.getItemById(id) ?: return@launch
+            libraryDao.delete(entity)
+            _sideEffect.emit(LibrarySideEffect.ShowToast("보관함에서 삭제되었습니다."))
         }
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/LibraryViewModel.kt
@@ -39,8 +39,7 @@ class LibraryViewModel(
 
     fun deleteItem(id: Long) {
         viewModelScope.launch {
-            val entity = libraryDao.getItemById(id) ?: return@launch
-            libraryDao.delete(entity)
+            libraryDao.deleteById(id)
             _sideEffect.emit(LibrarySideEffect.ShowToast("보관함에서 삭제되었습니다."))
         }
     }

--- a/app/src/main/java/com/example/letssopt/presentation/library/component/LibraryGridItem.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/component/LibraryGridItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,7 +26,7 @@ import com.example.letssopt.presentation.library.model.LibraryUiModel
 @Composable
 fun LibraryGridItem(
     item: LibraryUiModel,
-    onDeleteClick: (Int) -> Unit,
+    onDeleteClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -35,9 +36,19 @@ fun LibraryGridItem(
     ) {
         SoptContentItem(imageRes = item.imageRes)
 
+        Text(
+            text = item.title,
+            style = LETSSOPTTheme.typography.regular.body,
+            color = LETSSOPTTheme.colors.textPrimary,
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(top = 6.dp),
+            maxLines = 2
+        )
+
         Box(
             modifier = Modifier
-                .padding(top = 12.dp)
+                .padding(top = 8.dp)
                 .size(24.dp)
                 .clip(CircleShape)
                 .background(LETSSOPTTheme.colors.textPrimary)
@@ -58,7 +69,7 @@ fun LibraryGridItem(
 private fun LibraryGridItemPreview() {
     LETSSOPTTheme {
         LibraryGridItem(
-            item = LibraryUiModel(1, R.drawable.img_content1),
+            item = LibraryUiModel(1, R.drawable.img_content1, "이 사람 통역 되나요"),
             onDeleteClick = {}
         )
     }

--- a/app/src/main/java/com/example/letssopt/presentation/library/component/LibraryVerticalGrid.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/component/LibraryVerticalGrid.kt
@@ -18,7 +18,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun LibraryVerticalGrid(
     items: ImmutableList<LibraryUiModel>,
-    onDeleteClick: (Int) -> Unit,
+    onDeleteClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
@@ -45,9 +45,9 @@ private fun LibraryVerticalGridPreview() {
     LETSSOPTTheme {
         LibraryVerticalGrid(
             items = listOf(
-                LibraryUiModel(1, R.drawable.img_content1),
-                LibraryUiModel(2, R.drawable.img_content2),
-                LibraryUiModel(3, R.drawable.img_content3),
+                LibraryUiModel(1L, R.drawable.img_content1, "이 사람 통역 되나요"),
+                LibraryUiModel(2L, R.drawable.img_content2, "이상한일5"),
+                LibraryUiModel(3L, R.drawable.img_content3, "하일매리")
             ).toImmutableList(),
             onDeleteClick = {}
         )

--- a/app/src/main/java/com/example/letssopt/presentation/library/model/LibraryUiModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/model/LibraryUiModel.kt
@@ -1,9 +1,11 @@
 package com.example.letssopt.presentation.library.model
 
+import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Immutable
 
 @Immutable
 data class LibraryUiModel(
-    val id: Int,
-    val imageRes: Int
+    val id: Long,
+    @param:DrawableRes val imageRes: Int,
+    val title: String
 )

--- a/app/src/main/java/com/example/letssopt/presentation/library/navigation/LibraryNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/navigation/LibraryNavigation.kt
@@ -1,0 +1,32 @@
+package com.example.letssopt.presentation.library.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.example.letssopt.core.navigation.MainTabRoute
+import com.example.letssopt.presentation.library.LibraryRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigateLibrary(
+    navOptions: NavOptions? = null
+) {
+    navigate(Library, navOptions)
+}
+
+fun NavGraphBuilder.libraryGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
+) {
+    composable<Library> {
+        LibraryRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp
+        )
+    }
+}
+
+
+@Serializable
+data object Library: MainTabRoute

--- a/app/src/main/java/com/example/letssopt/presentation/library/state/LibraryContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/state/LibraryContract.kt
@@ -12,13 +12,15 @@ data class LibraryUiState(
 ) {
     companion object {
         val dummyItems = listOf(
-            LibraryUiModel(1, R.drawable.img_content1),
-            LibraryUiModel(2, R.drawable.img_content2),
-            LibraryUiModel(3, R.drawable.img_content3),
-            LibraryUiModel(4, R.drawable.img_content1),
-            LibraryUiModel(5, R.drawable.img_content2),
-            LibraryUiModel(6, R.drawable.img_content3),
-            LibraryUiModel(7, R.drawable.img_content1),
+            LibraryUiModel(1L, R.drawable.img_content1, "이 사람 통역 되나요"),
+            LibraryUiModel(2L, R.drawable.img_content2, "이상한일5"),
+            LibraryUiModel(3L, R.drawable.img_content3, "하일매리"),
+            LibraryUiModel(4L, R.drawable.img_content1, "이 사람 통역 되나요"),
+            LibraryUiModel(5L, R.drawable.img_content2, "이상한일5")
         )
     }
+}
+
+sealed interface LibrarySideEffect {
+    data class ShowToast(val message: String) : LibrarySideEffect
 }

--- a/app/src/main/java/com/example/letssopt/presentation/library/state/LibraryContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/library/state/LibraryContract.kt
@@ -5,6 +5,7 @@ import com.example.letssopt.R
 import com.example.letssopt.presentation.library.model.LibraryUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Immutable
 data class LibraryUiState(
@@ -17,7 +18,7 @@ data class LibraryUiState(
             LibraryUiModel(3L, R.drawable.img_content3, "하일매리"),
             LibraryUiModel(4L, R.drawable.img_content1, "이 사람 통역 되나요"),
             LibraryUiModel(5L, R.drawable.img_content2, "이상한일5")
-        )
+        ).toImmutableList()
     }
 }
 

--- a/app/src/main/java/com/example/letssopt/presentation/main/MainAppState.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/main/MainAppState.kt
@@ -86,14 +86,6 @@ class MainAppState(
         navController.navigate(SignUp)
     }
 
-    fun navigateToSignIn(email: String = "", password: String = "") {
-        navController.previousBackStackEntry?.savedStateHandle?.apply {
-            set("email", email)
-            set("password", password)
-        }
-        navController.navigateUp()
-    }
-
     private val clearStackNavOptions = navOptions {
         popUpTo(0) {
             inclusive = true

--- a/app/src/main/java/com/example/letssopt/presentation/main/MainAppState.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/main/MainAppState.kt
@@ -1,0 +1,115 @@
+package com.example.letssopt.presentation.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
+import com.example.letssopt.core.data.AuthPreference
+import com.example.letssopt.presentation.home.navigation.Home
+import com.example.letssopt.presentation.signin.navigation.SignIn
+import com.example.letssopt.presentation.signup.navigation.SignUp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@Stable
+class MainAppState(
+    val navController: NavHostController,
+    coroutineScope: CoroutineScope,
+) {
+    val startDestination = if (AuthPreference.isLoggedIn()) Home else SignIn
+
+    private val currentDestination = navController.currentBackStackEntryFlow
+        .map { it.destination }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = null
+        )
+
+    val currentTab: StateFlow<MainTab?> = currentDestination
+        .map { destination ->
+            MainTab.find { tab ->
+                destination?.hasRoute(tab::class) == true
+            }
+        }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+
+    val isBottomBarVisible: StateFlow<Boolean> = currentDestination
+        .map { destination ->
+            MainTab.contains { tab ->
+                destination?.hasRoute(tab::class) == true
+            }
+        }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false
+        )
+
+    fun navigate(tab: MainTab) {
+        val navOptions = navOptions {
+            navController.currentDestination?.route?.let {
+                popUpTo(it) {
+                    inclusive = true
+                    saveState = true
+                }
+                restoreState = true
+                launchSingleTop = true
+            }
+        }
+        navController.navigate(tab.route, navOptions)
+    }
+
+    fun navigateUp() {
+        navController.navigateUp()
+    }
+
+    fun navigateToMain() {
+        navController.navigate(Home) {
+            popUpTo(0) { inclusive = true }
+            launchSingleTop = true
+        }
+    }
+
+    fun navigateToSignUp() {
+        navController.navigate(SignUp)
+    }
+
+    fun navigateToSignIn(email: String = "", password: String = "") {
+        navController.previousBackStackEntry?.savedStateHandle?.apply {
+            set("email", email)
+            set("password", password)
+        }
+        navController.navigateUp()
+    }
+
+    private val clearStackNavOptions = navOptions {
+        popUpTo(0) {
+            inclusive = true
+        }
+        launchSingleTop = true
+    }
+
+}
+
+@Composable
+fun rememberMainAppState(
+    navController: NavHostController = rememberNavController(),
+    coroutineScope: CoroutineScope = rememberCoroutineScope()
+): MainAppState = remember(navController,coroutineScope) {
+    MainAppState(
+        navController,
+        coroutineScope,
+    )
+}

--- a/app/src/main/java/com/example/letssopt/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/main/MainScreen.kt
@@ -1,29 +1,37 @@
 package com.example.letssopt.presentation.main
 
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.NavHost
 import com.example.letssopt.core.designsystem.component.SoptTopBar
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
-import com.example.letssopt.presentation.home.HomeRoute
-import com.example.letssopt.presentation.library.LibraryRoute
+import com.example.letssopt.presentation.home.navigation.homeGraph
+import com.example.letssopt.presentation.library.navigation.libraryGraph
 import com.example.letssopt.presentation.main.component.MainBottomBar
-import com.example.letssopt.presentation.purchase.PurchaseScreen
-import com.example.letssopt.presentation.search.SearchScreen
-import com.example.letssopt.presentation.webtoon.WebtoonScreen
-import kotlinx.collections.immutable.toImmutableList
+import com.example.letssopt.presentation.purchase.navigation.purchaseGraph
+import com.example.letssopt.presentation.search.navigation.searchGraph
+import com.example.letssopt.presentation.signin.navigation.signInGraph
+import com.example.letssopt.presentation.signup.navigation.signUpGraph
+import com.example.letssopt.presentation.webtoon.navigation.webtoonGraph
+import kotlinx.collections.immutable.toPersistentList
 
 @Composable
-fun MainScreen(modifier: Modifier = Modifier) {
-    var currentTab by remember { mutableStateOf(MainTab.MAIN) }
+fun MainScreen(
+    modifier: Modifier = Modifier,
+    appState: MainAppState = rememberMainAppState(),
+) {
+    val isBottomBarVisible by appState.isBottomBarVisible.collectAsStateWithLifecycle()
+    val currentTab by appState.currentTab.collectAsStateWithLifecycle()
 
     Scaffold(
         modifier = modifier
@@ -32,10 +40,10 @@ fun MainScreen(modifier: Modifier = Modifier) {
             .statusBarsPadding(),
         bottomBar = {
             MainBottomBar(
-                isVisible = true,
-                tabs = MainTab.entries.toImmutableList(),
+                isVisible = isBottomBarVisible,
+                tabs = MainTab.entries.toPersistentList(),
                 currentTab = currentTab,
-                onTabSelected = { currentTab = it }
+                onTabSelected = appState::navigate
             )
         },
         topBar = {
@@ -45,13 +53,67 @@ fun MainScreen(modifier: Modifier = Modifier) {
             }
         },
 
-    ) { innerPadding ->
-        when (currentTab) {
-            MainTab.MAIN -> HomeRoute(paddingValues = innerPadding)
-            MainTab.PURCHASE -> PurchaseScreen(paddingValues = innerPadding)
-            MainTab.WEBTOON -> WebtoonScreen(paddingValues = innerPadding)
-            MainTab.SEARCH -> SearchScreen(paddingValues = innerPadding)
-            MainTab.LIBRARY -> LibraryRoute(paddingValues = innerPadding)
+        ) { innerPadding ->
+        NavHost(
+            enterTransition = {
+                slideInHorizontally(
+                    initialOffsetX = { fullWidth -> fullWidth },
+                    animationSpec = tween(durationMillis = 300)
+                )
+            },
+            exitTransition = {
+                slideOutHorizontally(
+                    targetOffsetX = { fullWidth -> -fullWidth },
+                    animationSpec = tween(durationMillis = 300)
+                )
+            },
+            popEnterTransition = {
+                slideInHorizontally(
+                    initialOffsetX = { fullWidth -> -fullWidth },
+                    animationSpec = tween(durationMillis = 300)
+                )
+            },
+            popExitTransition = {
+                slideOutHorizontally(
+                    targetOffsetX = { fullWidth -> fullWidth },
+                    animationSpec = tween(durationMillis = 300)
+                )
+            },
+            navController = appState.navController,
+            startDestination = appState.startDestination
+        ) {
+            signInGraph(
+                paddingValues = innerPadding,
+                navigateUp = appState::navigateUp,
+                navigateToSignUp = appState::navigateToSignUp,
+                navigateToMain = appState::navigateToMain
+            )
+
+            signUpGraph(
+                paddingValues = innerPadding,
+                navigateUp = appState::navigateUp,
+            )
+
+            homeGraph(
+                paddingValues = innerPadding,
+                navigateUp = appState::navigateUp
+            )
+            purchaseGraph(
+                paddingValues = innerPadding,
+                navigateUp = appState::navigateUp
+            )
+            webtoonGraph(
+                paddingValues = innerPadding,
+                navigateUp = appState::navigateUp
+            )
+            searchGraph(
+                paddingValues = innerPadding,
+                navigateUp = appState::navigateUp
+            )
+            libraryGraph(
+                paddingValues = innerPadding,
+                navigateUp = appState::navigateUp
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/main/MainTab.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/main/MainTab.kt
@@ -3,29 +3,53 @@ package com.example.letssopt.presentation.main
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.example.letssopt.R
+import com.example.letssopt.core.navigation.MainTabRoute
+import com.example.letssopt.core.navigation.Route
+import com.example.letssopt.presentation.home.navigation.Home
+import com.example.letssopt.presentation.library.navigation.Library
+import com.example.letssopt.presentation.purchase.navigation.Purchase
+import com.example.letssopt.presentation.search.navigation.Search
+import com.example.letssopt.presentation.webtoon.navigation.Webtoon
 
 enum class MainTab(
     @param:DrawableRes val icon: Int,
     @param:StringRes val contentDescription: Int,
-) {
+    val route: MainTabRoute,
+    ) {
     MAIN(
         icon = R.drawable.ic_main,
-        contentDescription = R.string.tab_main
+        contentDescription = R.string.tab_main,
+        route = Home
     ),
     PURCHASE(
         icon = R.drawable.ic_purchase,
-        contentDescription = R.string.tab_purchase
+        contentDescription = R.string.tab_purchase,
+        route = Purchase
     ),
     WEBTOON(
         icon = R.drawable.ic_webtoon,
-        contentDescription = R.string.tab_webtoon
+        contentDescription = R.string.tab_webtoon,
+        route = Webtoon
     ),
     SEARCH(
         icon = R.drawable.ic_search,
-        contentDescription = R.string.tab_search
+        contentDescription = R.string.tab_search,
+        route = Search
     ),
     LIBRARY(
         icon = R.drawable.ic_library,
-        contentDescription = R.string.tab_library
-    )
+        contentDescription = R.string.tab_library,
+        route = Library
+    );
+
+
+    companion object {
+        fun find(predicate: (MainTabRoute) -> Boolean): MainTab? {
+            return MainTab.entries.find { predicate(it.route) }
+        }
+
+        fun contains(predicate: (Route) -> Boolean): Boolean {
+            return MainTab.entries.map { it.route }.any { predicate(it) }
+        }
+    }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/main/component/MainBottomBar.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/main/component/MainBottomBar.kt
@@ -65,7 +65,7 @@ fun MainBottomBar(
 }
 
 @Composable
-fun MainBottomBarTab(
+private fun MainBottomBarTab(
     tab: MainTab,
     isSelected: Boolean,
     onClick: () -> Unit,

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
@@ -14,12 +14,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.letssopt.core.data.LibraryDatabase
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
 import com.example.letssopt.presentation.purchase.component.PurchaseVerticalGrid
+import com.example.letssopt.presentation.purchase.model.PurchaseUiModel
 import com.example.letssopt.presentation.purchase.state.PurchaseSideEffect
 import com.example.letssopt.presentation.purchase.state.PurchaseUiState
 import kotlinx.coroutines.flow.collectLatest
@@ -51,8 +53,7 @@ fun PurchaseRoute(
     PurchaseScreen(
         paddingValues = paddingValues,
         uiState = uiState,
-        onPurchaseClick = { id, imageRes, title ->
-            viewModel.onPurchaseClick(id = id, title = title, imageRes = imageRes)        }
+        onPurchaseClick = { viewModel.onPurchaseClick(it) }
     )
 }
 
@@ -60,7 +61,7 @@ fun PurchaseRoute(
 private fun PurchaseScreen(
     paddingValues: PaddingValues,
     uiState: PurchaseUiState,
-    onPurchaseClick: (Long, Int, String) -> Unit
+    onPurchaseClick: (PurchaseUiModel) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -79,6 +80,20 @@ private fun PurchaseScreen(
         PurchaseVerticalGrid(
             items = uiState.items,
             onPurchaseClick = onPurchaseClick
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PurchaseScreenPreview() {
+    LETSSOPTTheme {
+        PurchaseScreen(
+            paddingValues = PaddingValues(0.dp),
+            uiState = PurchaseUiState(
+                items = PurchaseUiState.dummyItems
+            ),
+            onPurchaseClick = {}
         )
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
@@ -1,38 +1,84 @@
 package com.example.letssopt.presentation.purchase
 
-import androidx.compose.foundation.layout.Arrangement
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.letssopt.core.data.LibraryDatabase
+import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
+import com.example.letssopt.presentation.purchase.component.PurchaseVerticalGrid
+import com.example.letssopt.presentation.purchase.state.PurchaseSideEffect
+import com.example.letssopt.presentation.purchase.state.PurchaseUiState
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun PurchaseRoute(
     paddingValues: PaddingValues,
     navigateUp: () -> Unit
 ) {
+    val context = LocalContext.current
+    val database = remember { LibraryDatabase.getDatabase(context) }
+
+    val viewModel: PurchaseViewModel = viewModel {
+        PurchaseViewModel(database.libraryDao())
+    }
+
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collectLatest { effect ->
+            when (effect) {
+                is PurchaseSideEffect.ShowToast -> {
+                    Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
     PurchaseScreen(
-        paddingValues = paddingValues
+        paddingValues = paddingValues,
+        uiState = uiState,
+        onPurchaseClick = { id, imageRes, title ->
+            viewModel.onPurchaseClick(id = id, title = title, imageRes = imageRes)        }
     )
 }
 
 @Composable
 private fun PurchaseScreen(
-    paddingValues: PaddingValues
+    paddingValues: PaddingValues,
+    uiState: PurchaseUiState,
+    onPurchaseClick: (Long, Int, String) -> Unit
 ) {
-    Column (
+    Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(paddingValues),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(paddingValues)
+            .padding(horizontal = 16.dp)
     ) {
         Text(
-            text = "Purchase"
+            text = "개별 구매",
+            style = LETSSOPTTheme.typography.bold.h1,
+            color = LETSSOPTTheme.colors.textPrimary,
+            modifier = Modifier.padding(top = 70.dp)
+        )
+        Spacer(modifier = Modifier.height(45.dp))
+
+        PurchaseVerticalGrid(
+            items = uiState.items,
+            onPurchaseClick = onPurchaseClick
         )
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
@@ -12,7 +12,8 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun PurchaseRoute(
-    paddingValues: PaddingValues
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
 ) {
     PurchaseScreen(
         paddingValues = paddingValues
@@ -20,7 +21,7 @@ fun PurchaseRoute(
 }
 
 @Composable
-fun PurchaseScreen(
+private fun PurchaseScreen(
     paddingValues: PaddingValues
 ) {
     Column (

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseScreen.kt
@@ -40,7 +40,7 @@ fun PurchaseRoute(
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(viewModel.sideEffect) {
+    LaunchedEffect(viewModel) {
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
                 is PurchaseSideEffect.ShowToast -> {

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseViewModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseViewModel.kt
@@ -1,0 +1,43 @@
+package com.example.letssopt.presentation.purchase
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.letssopt.core.data.LibraryDao
+import com.example.letssopt.core.data.LibraryEntity
+import com.example.letssopt.presentation.purchase.state.PurchaseSideEffect
+import com.example.letssopt.presentation.purchase.state.PurchaseUiState
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class PurchaseViewModel(
+    private val libraryDao: LibraryDao
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(
+        PurchaseUiState(
+            items = PurchaseUiState.dummyItems.toImmutableList()
+        )
+    )
+    val uiState = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<PurchaseSideEffect>()
+    val sideEffect: SharedFlow<PurchaseSideEffect> = _sideEffect.asSharedFlow()
+
+    fun onPurchaseClick(id: Long, title: String, imageRes: Int) {
+        viewModelScope.launch {
+            val existing = libraryDao.getItemById(id)
+
+            if (existing != null) {
+                _sideEffect.emit(PurchaseSideEffect.ShowToast("이미 보관함에 있는 작품입니다."))
+                return@launch
+            }
+
+            libraryDao.insert(LibraryEntity(id = id, title = title, imageRes = imageRes))
+            _sideEffect.emit(PurchaseSideEffect.ShowToast("${title}을(를) 보관함에 담았습니다!"))
+        }
+    }
+}

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseViewModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/PurchaseViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.letssopt.core.data.LibraryDao
 import com.example.letssopt.core.data.LibraryEntity
+import com.example.letssopt.presentation.purchase.model.PurchaseUiModel
 import com.example.letssopt.presentation.purchase.state.PurchaseSideEffect
 import com.example.letssopt.presentation.purchase.state.PurchaseUiState
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -19,7 +19,7 @@ class PurchaseViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(
         PurchaseUiState(
-            items = PurchaseUiState.dummyItems.toImmutableList()
+            items = PurchaseUiState.dummyItems
         )
     )
     val uiState = _uiState.asStateFlow()
@@ -27,17 +27,17 @@ class PurchaseViewModel(
     private val _sideEffect = MutableSharedFlow<PurchaseSideEffect>()
     val sideEffect: SharedFlow<PurchaseSideEffect> = _sideEffect.asSharedFlow()
 
-    fun onPurchaseClick(id: Long, title: String, imageRes: Int) {
+    fun onPurchaseClick(item: PurchaseUiModel) {
         viewModelScope.launch {
-            val existing = libraryDao.getItemById(id)
+            val existing = libraryDao.getItemById(item.id)
 
             if (existing != null) {
                 _sideEffect.emit(PurchaseSideEffect.ShowToast("이미 보관함에 있는 작품입니다."))
                 return@launch
             }
 
-            libraryDao.insert(LibraryEntity(id = id, title = title, imageRes = imageRes))
-            _sideEffect.emit(PurchaseSideEffect.ShowToast("${title}을(를) 보관함에 담았습니다!"))
+            libraryDao.insert(LibraryEntity(id = item.id, title = item.title, imageRes = item.imageRes))
+            _sideEffect.emit(PurchaseSideEffect.ShowToast("${item.title}을(를) 보관함에 담았습니다!"))
         }
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseGridItem.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseGridItem.kt
@@ -1,0 +1,84 @@
+package com.example.letssopt.presentation.purchase.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.letssopt.R
+import com.example.letssopt.core.common.extension.noRippleClickable
+import com.example.letssopt.core.designsystem.component.SoptContentItem
+import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
+import com.example.letssopt.presentation.purchase.model.PurchaseUiModel
+
+@Composable
+fun PurchaseGridItem(
+    item: PurchaseUiModel,
+    onPurchaseClick: (Long, Int, String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Box {
+            SoptContentItem(
+                imageRes = item.imageRes,
+                modifier = Modifier
+                    .fillMaxWidth()
+            )
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 6.dp, end = 6.dp)
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black)
+                    .noRippleClickable { onPurchaseClick(item.id, item.imageRes, item.title) },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_ticket),
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier
+                        .padding(5.dp)
+                        .size(18.dp)
+                )
+            }
+        }
+
+        Text(
+            text = item.title,
+            style = LETSSOPTTheme.typography.regular.body,
+            color = LETSSOPTTheme.colors.textPrimary,
+            modifier = Modifier.padding(top = 6.dp),
+            maxLines = 2
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PurchaseGridItemPreview() {
+    LETSSOPTTheme {
+        PurchaseGridItem(
+            item = PurchaseUiModel(1, R.drawable.img_content1, "이 사람 통역 되나요"),
+            onPurchaseClick = { _, _, _ -> }
+        )
+    }
+}

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseGridItem.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseGridItem.kt
@@ -27,7 +27,7 @@ import com.example.letssopt.presentation.purchase.model.PurchaseUiModel
 @Composable
 fun PurchaseGridItem(
     item: PurchaseUiModel,
-    onPurchaseClick: (Long, Int, String) -> Unit,
+    onPurchaseClick: (PurchaseUiModel) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -48,7 +48,7 @@ fun PurchaseGridItem(
                     .size(28.dp)
                     .clip(CircleShape)
                     .background(Color.Black)
-                    .noRippleClickable { onPurchaseClick(item.id, item.imageRes, item.title) },
+                    .noRippleClickable { onPurchaseClick(item) },
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
@@ -78,7 +78,7 @@ private fun PurchaseGridItemPreview() {
     LETSSOPTTheme {
         PurchaseGridItem(
             item = PurchaseUiModel(1, R.drawable.img_content1, "이 사람 통역 되나요"),
-            onPurchaseClick = { _, _, _ -> }
+            onPurchaseClick = {}
         )
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseVerticalGrid.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseVerticalGrid.kt
@@ -1,0 +1,57 @@
+package com.example.letssopt.presentation.purchase.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.letssopt.R
+import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
+import com.example.letssopt.presentation.purchase.model.PurchaseUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+fun PurchaseVerticalGrid(
+    items: ImmutableList<PurchaseUiModel>,
+    onPurchaseClick: (Long, Int, String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        modifier = modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        items(
+            items = items,
+            key = { it.id }
+        ) { item ->
+            PurchaseGridItem(
+                item = item,
+                onPurchaseClick = onPurchaseClick
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PurchaseVerticalGridPreview() {
+    LETSSOPTTheme {
+        PurchaseVerticalGrid(
+            items = listOf(
+                PurchaseUiModel(1, R.drawable.img_content1, "이 사람 통역 되나요"),
+                PurchaseUiModel(2, R.drawable.img_content2, "이상한일5"),
+                PurchaseUiModel(3, R.drawable.img_content3, "하일매리"),
+                PurchaseUiModel(4, R.drawable.img_content1, "이 사람 통역 되나요"),
+                PurchaseUiModel(5, R.drawable.img_content2, "이상한일5")
+            ).toImmutableList(),
+            onPurchaseClick = { _, _, _ -> }
+        )
+    }
+}

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseVerticalGrid.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/component/PurchaseVerticalGrid.kt
@@ -18,7 +18,7 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun PurchaseVerticalGrid(
     items: ImmutableList<PurchaseUiModel>,
-    onPurchaseClick: (Long, Int, String) -> Unit,
+    onPurchaseClick: (PurchaseUiModel) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
@@ -51,7 +51,7 @@ private fun PurchaseVerticalGridPreview() {
                 PurchaseUiModel(4, R.drawable.img_content1, "이 사람 통역 되나요"),
                 PurchaseUiModel(5, R.drawable.img_content2, "이상한일5")
             ).toImmutableList(),
-            onPurchaseClick = { _, _, _ -> }
+            onPurchaseClick = {}
         )
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/model/PurchaseUiModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/model/PurchaseUiModel.kt
@@ -1,0 +1,11 @@
+package com.example.letssopt.presentation.purchase.model
+
+import androidx.annotation.DrawableRes
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class PurchaseUiModel(
+    val id: Long,
+    @param:DrawableRes val imageRes: Int,
+    val title: String
+)

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/navigation/PurchaseNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/navigation/PurchaseNavigation.kt
@@ -1,0 +1,32 @@
+package com.example.letssopt.presentation.purchase.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.example.letssopt.core.navigation.MainTabRoute
+import com.example.letssopt.presentation.purchase.PurchaseRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigatePurchase(
+    navOptions: NavOptions? = null
+) {
+    navigate(Purchase, navOptions)
+}
+
+fun NavGraphBuilder.purchaseGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
+) {
+    composable<Purchase> {
+        PurchaseRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp
+        )
+    }
+}
+
+
+@Serializable
+data object Purchase: MainTabRoute

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/state/PurchaseContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/state/PurchaseContract.kt
@@ -5,6 +5,7 @@ import com.example.letssopt.R
 import com.example.letssopt.presentation.purchase.model.PurchaseUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Immutable
 data class PurchaseUiState(
@@ -17,7 +18,7 @@ data class PurchaseUiState(
             PurchaseUiModel(3L, R.drawable.img_content3, "하일매리"),
             PurchaseUiModel(4L, R.drawable.img_content1, "이 사람 통역 되나요"),
             PurchaseUiModel(5L, R.drawable.img_content2, "이상한일5")
-        )
+        ).toImmutableList()
     }
 }
 

--- a/app/src/main/java/com/example/letssopt/presentation/purchase/state/PurchaseContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/purchase/state/PurchaseContract.kt
@@ -1,0 +1,26 @@
+package com.example.letssopt.presentation.purchase.state
+
+import androidx.compose.runtime.Immutable
+import com.example.letssopt.R
+import com.example.letssopt.presentation.purchase.model.PurchaseUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Immutable
+data class PurchaseUiState(
+    val items: ImmutableList<PurchaseUiModel> = persistentListOf()
+) {
+    companion object {
+        val dummyItems = listOf(
+            PurchaseUiModel(1L, R.drawable.img_content1, "이 사람 통역 되나요"),
+            PurchaseUiModel(2L, R.drawable.img_content2, "이상한일5"),
+            PurchaseUiModel(3L, R.drawable.img_content3, "하일매리"),
+            PurchaseUiModel(4L, R.drawable.img_content1, "이 사람 통역 되나요"),
+            PurchaseUiModel(5L, R.drawable.img_content2, "이상한일5")
+        )
+    }
+}
+
+sealed interface PurchaseSideEffect {
+    data class ShowToast(val message: String) : PurchaseSideEffect
+}

--- a/app/src/main/java/com/example/letssopt/presentation/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/search/SearchScreen.kt
@@ -12,7 +12,8 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun SearchRoute(
-    paddingValues: PaddingValues
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
 ) {
     SearchScreen(
         paddingValues = paddingValues
@@ -20,8 +21,8 @@ fun SearchRoute(
 }
 
 @Composable
-fun SearchScreen(
-    paddingValues: PaddingValues
+private fun SearchScreen(
+    paddingValues: PaddingValues,
 ) {
     Column (
         modifier = Modifier

--- a/app/src/main/java/com/example/letssopt/presentation/search/navigation/SearchNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/search/navigation/SearchNavigation.kt
@@ -1,0 +1,32 @@
+package com.example.letssopt.presentation.search.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.example.letssopt.core.navigation.MainTabRoute
+import com.example.letssopt.presentation.search.SearchRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigateSearch(
+    navOptions: NavOptions? = null
+) {
+    navigate(Search, navOptions)
+}
+
+fun NavGraphBuilder.searchGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
+) {
+    composable<Search> {
+        SearchRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp
+        )
+    }
+}
+
+
+@Serializable
+data object Search: MainTabRoute

--- a/app/src/main/java/com/example/letssopt/presentation/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signin/SignInScreen.kt
@@ -1,14 +1,9 @@
 package com.example.letssopt.presentation.signin
 
-import android.content.Intent
-import android.os.Bundle
 import android.widget.Toast
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -19,7 +14,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.KeyboardActionHandler
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,62 +23,27 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.letssopt.core.common.extension.noRippleClickable
 import com.example.letssopt.core.data.AuthPreference
 import com.example.letssopt.core.designsystem.component.SoptBasicButton
 import com.example.letssopt.core.designsystem.component.SoptFormField
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
-import com.example.letssopt.presentation.main.MainActivity
-import com.example.letssopt.presentation.signup.SignUpActivity
-
-class SignInActivity : ComponentActivity() {
-    private val viewModel by viewModels<SignInViewModel>()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        if (AuthPreference.isLoggedIn()) {
-            startMainActivity()
-            return
-        }
-
-        enableEdgeToEdge()
-        setContent {
-            LETSSOPTTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    SignInRoute(
-                        modifier = Modifier.padding(innerPadding),
-                        viewModel = viewModel,
-                        navigateToSignUp = {
-                            val intent = Intent(this@SignInActivity, SignUpActivity::class.java)
-                            startActivity(intent)
-                        },
-                        navigateToMain = { startMainActivity() }
-                    )
-                }
-            }
-        }
-    }
-
-    private fun startMainActivity() {
-        val intent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        startActivity(intent)
-        finish()
-    }
-}
 
 @Composable
 fun SignInRoute(
-    viewModel: SignInViewModel,
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
     navigateToSignUp: () -> Unit,
     navigateToMain: () -> Unit,
     modifier: Modifier = Modifier,
-) {
+    viewModel: SignInViewModel = viewModel(),
+
+    ) {
     val context = LocalContext.current
 
     SignInScreen(
+        paddingValues = paddingValues,
         modifier = modifier,
         onSignUpTextClick = navigateToSignUp,
         onSignInClick = { email, password ->
@@ -103,13 +62,15 @@ fun SignInRoute(
             } else {
                 AuthPreference.setLoggedIn(true)
                 Toast.makeText(context, "로그인에 성공했습니다", Toast.LENGTH_SHORT).show()
-                navigateToMain()}
+                navigateToMain()
+            }
         }
     )
 }
 
 @Composable
 private fun SignInScreen(
+    paddingValues: PaddingValues,
     onSignUpTextClick: () -> Unit,
     onSignInClick: (String, String) -> Unit,
     modifier: Modifier = Modifier
@@ -123,6 +84,7 @@ private fun SignInScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = LETSSOPTTheme.colors.background)
+            .padding(paddingValues)
             .padding(horizontal = 20.dp)
             .imePadding(),
         horizontalAlignment = Alignment.Start
@@ -172,7 +134,7 @@ private fun SignInScreen(
                 }
             )
         }
-        
+
         Text(
             text = "아직 계정이 없으신가요?  회원가입",
             style = LETSSOPTTheme.typography.regular.caption,
@@ -204,6 +166,7 @@ fun SignInScreenPreview() {
     LETSSOPTTheme {
         SignInScreen(
             onSignUpTextClick = {},
+            paddingValues = PaddingValues(),
             onSignInClick = { _, _ -> }
         )
     }

--- a/app/src/main/java/com/example/letssopt/presentation/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signin/SignInScreen.kt
@@ -44,7 +44,7 @@ fun SignInRoute(
     ) {
     val context = LocalContext.current
 
-    LaunchedEffect(viewModel.sideEffect) {
+    LaunchedEffect(viewModel) {
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
                 is SignInSideEffect.ShowToast -> {

--- a/app/src/main/java/com/example/letssopt/presentation/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signin/SignInScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -25,10 +26,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.letssopt.core.common.extension.noRippleClickable
-import com.example.letssopt.core.data.AuthPreference
 import com.example.letssopt.core.designsystem.component.SoptBasicButton
 import com.example.letssopt.core.designsystem.component.SoptFormField
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
+import com.example.letssopt.presentation.signin.state.SignInSideEffect
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun SignInRoute(
@@ -42,29 +44,27 @@ fun SignInRoute(
     ) {
     val context = LocalContext.current
 
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collectLatest { effect ->
+            when (effect) {
+                is SignInSideEffect.ShowToast -> {
+                    Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                }
+                is SignInSideEffect.NavigateToMain -> {
+                    navigateToMain()
+                }
+                is SignInSideEffect.NavigateToSignUp -> {
+                    navigateToSignUp()
+                }
+            }
+        }
+    }
+
     SignInScreen(
         paddingValues = paddingValues,
         modifier = modifier,
-        onSignUpTextClick = navigateToSignUp,
-        onSignInClick = { email, password ->
-            val storedEmail = AuthPreference.getEmail()
-            val storedPassword = AuthPreference.getPassword()
-
-            val errorMessage = viewModel.validateSignIn(
-                email = email,
-                password = password,
-                storedEmail = storedEmail,
-                storedPassword = storedPassword
-            )
-
-            if (errorMessage != null) {
-                Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-            } else {
-                AuthPreference.setLoggedIn(true)
-                Toast.makeText(context, "로그인에 성공했습니다", Toast.LENGTH_SHORT).show()
-                navigateToMain()
-            }
-        }
+        onSignUpTextClick = viewModel::onSignUpTextClick,
+        onSignInClick = viewModel::signIn
     )
 }
 

--- a/app/src/main/java/com/example/letssopt/presentation/signin/SignInViewModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signin/SignInViewModel.kt
@@ -1,25 +1,44 @@
 package com.example.letssopt.presentation.signin
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.letssopt.core.common.util.SoptValidator
+import com.example.letssopt.core.data.AuthPreference
+import com.example.letssopt.presentation.signin.state.SignInSideEffect
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 
 class SignInViewModel : ViewModel() {
-    fun validateSignIn(
-        email: String,
-        password: String,
-        storedEmail: String,
-        storedPassword: String
-    ): String? {
-        val errorType = SoptValidator.validateSignInInputs(email, password)
 
-        if (errorType != null) {
-            return errorType.message
+    private val _sideEffect = MutableSharedFlow<SignInSideEffect>()
+    val sideEffect: SharedFlow<SignInSideEffect> = _sideEffect.asSharedFlow()
+
+    fun onSignUpTextClick() {
+        viewModelScope.launch {
+            _sideEffect.emit(SignInSideEffect.NavigateToSignUp)
         }
+    }
 
-        if (email != storedEmail || password != storedPassword) {
-            return "아이디 또는 비밀번호가 일치하지 않습니다."
+    fun signIn(email: String, password: String) {
+        viewModelScope.launch {
+            val storedEmail = AuthPreference.getEmail()
+            val storedPassword = AuthPreference.getPassword()
+
+            val errorType = SoptValidator.validateSignInInputs(email, password)
+            if (errorType != null) {
+                _sideEffect.emit(SignInSideEffect.ShowToast(errorType.message))
+                return@launch
+            }
+
+            if (email != storedEmail || password != storedPassword) {
+                _sideEffect.emit(SignInSideEffect.ShowToast("아이디 또는 비밀번호가 일치하지 않습니다."))
+            } else {
+                AuthPreference.setLoggedIn(true)
+                _sideEffect.emit(SignInSideEffect.ShowToast("로그인에 성공했습니다"))
+                _sideEffect.emit(SignInSideEffect.NavigateToMain)
+            }
         }
-
-        return null
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/signin/navigation/SignInNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signin/navigation/SignInNavigation.kt
@@ -1,0 +1,36 @@
+package com.example.letssopt.presentation.signin.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.example.letssopt.core.navigation.Route
+import com.example.letssopt.presentation.signin.SignInRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigateSignIn(
+    navOptions: NavOptions? = null
+) {
+    navigate(SignIn, navOptions)
+}
+
+fun NavGraphBuilder.signInGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
+    navigateToSignUp: () -> Unit,
+    navigateToMain: () -> Unit
+) {
+    composable<SignIn> {
+        SignInRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp,
+            navigateToSignUp = navigateToSignUp,
+            navigateToMain = navigateToMain
+        )
+    }
+}
+
+
+@Serializable
+data object SignIn: Route

--- a/app/src/main/java/com/example/letssopt/presentation/signin/state/SignInContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signin/state/SignInContract.kt
@@ -1,0 +1,7 @@
+package com.example.letssopt.presentation.signin.state
+
+sealed interface SignInSideEffect {
+    data class ShowToast(val message: String) : SignInSideEffect
+    data object NavigateToMain : SignInSideEffect
+    data object NavigateToSignUp : SignInSideEffect
+}

--- a/app/src/main/java/com/example/letssopt/presentation/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signup/SignUpScreen.kt
@@ -40,7 +40,7 @@ fun SignUpRoute(
     ) {
     val context = LocalContext.current
 
-    LaunchedEffect(viewModel.sideEffect) {
+    LaunchedEffect(viewModel) {
         viewModel.sideEffect.collectLatest { effect ->
             when (effect) {
                 is SignUpSideEffect.ShowToast -> {

--- a/app/src/main/java/com/example/letssopt/presentation/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signup/SignUpScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -24,10 +25,11 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.letssopt.core.data.AuthPreference
 import com.example.letssopt.core.designsystem.component.SoptBasicButton
 import com.example.letssopt.core.designsystem.component.SoptFormField
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
+import com.example.letssopt.presentation.signup.state.SignUpSideEffect
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun SignUpRoute(
@@ -38,20 +40,23 @@ fun SignUpRoute(
     ) {
     val context = LocalContext.current
 
+    LaunchedEffect(viewModel.sideEffect) {
+        viewModel.sideEffect.collectLatest { effect ->
+            when (effect) {
+                is SignUpSideEffect.ShowToast -> {
+                    Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                }
+                is SignUpSideEffect.NavigateToSignIn -> {
+                    navigateUp()
+                }
+            }
+        }
+    }
+
     SignUpScreen(
         paddingValues = paddingValues,
         modifier = modifier,
-        onSignUpClick = { email, password, passwordCheck ->
-            val errorMessage = viewModel.validateSignUp(email, password, passwordCheck)
-
-            if (errorMessage != null) {
-                Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-            } else {
-                AuthPreference.saveAccount(email, password)
-                Toast.makeText(context, "회원가입에 성공했습니다.", Toast.LENGTH_SHORT).show()
-                navigateUp()
-            }
-        }
+        onSignUpClick = viewModel::signUp
     )
 }
 

--- a/app/src/main/java/com/example/letssopt/presentation/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signup/SignUpScreen.kt
@@ -1,14 +1,9 @@
 package com.example.letssopt.presentation.signup
 
-import android.content.Intent
-import android.os.Bundle
 import android.widget.Toast
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -19,7 +14,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.KeyboardActionHandler
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,47 +23,23 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.letssopt.core.data.AuthPreference
 import com.example.letssopt.core.designsystem.component.SoptBasicButton
 import com.example.letssopt.core.designsystem.component.SoptFormField
 import com.example.letssopt.core.designsystem.theme.LETSSOPTTheme
 
-class SignUpActivity : ComponentActivity() {
-    private val viewModel by viewModels<SignUpViewModel>()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            LETSSOPTTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    SignUpRoute(
-                        modifier = Modifier.padding(innerPadding),
-                        viewModel = viewModel,
-                        navigateToSignIn = { email, password ->
-                            val intent = Intent().apply {
-                                putExtra("email", email)
-                                putExtra("password", password)
-                            }
-                            setResult(RESULT_OK, intent)
-                            finish()
-                        }
-                    )
-                }
-            }
-        }
-    }
-}
-
 @Composable
 fun SignUpRoute(
-    viewModel: SignUpViewModel,
-    navigateToSignIn: (String, String) -> Unit,
-    modifier: Modifier = Modifier
-) {
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SignUpViewModel = viewModel(),
+    ) {
     val context = LocalContext.current
 
     SignUpScreen(
+        paddingValues = paddingValues,
         modifier = modifier,
         onSignUpClick = { email, password, passwordCheck ->
             val errorMessage = viewModel.validateSignUp(email, password, passwordCheck)
@@ -79,7 +49,7 @@ fun SignUpRoute(
             } else {
                 AuthPreference.saveAccount(email, password)
                 Toast.makeText(context, "회원가입에 성공했습니다.", Toast.LENGTH_SHORT).show()
-                navigateToSignIn(email, password)
+                navigateUp()
             }
         }
     )
@@ -87,6 +57,7 @@ fun SignUpRoute(
 
 @Composable
 private fun SignUpScreen(
+    paddingValues: PaddingValues,
     onSignUpClick: (String, String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -100,6 +71,7 @@ private fun SignUpScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = LETSSOPTTheme.colors.background)
+            .padding(paddingValues)
             .padding(horizontal = 20.dp)
             .imePadding(),
         horizontalAlignment = Alignment.Start
@@ -182,6 +154,7 @@ private fun SignUpScreen(
 fun SignUpScreenPreview() {
     LETSSOPTTheme {
         SignUpScreen(
+            paddingValues = PaddingValues(),
             onSignUpClick = { _, _, _ -> }
         )
     }

--- a/app/src/main/java/com/example/letssopt/presentation/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signup/SignUpViewModel.kt
@@ -1,15 +1,35 @@
 package com.example.letssopt.presentation.signup
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.letssopt.core.common.util.SoptValidator
+import com.example.letssopt.core.data.AuthPreference
+import com.example.letssopt.presentation.signup.state.SignUpSideEffect
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 
 class SignUpViewModel : ViewModel() {
-    fun validateSignUp(
+
+    private val _sideEffect = MutableSharedFlow<SignUpSideEffect>()
+    val sideEffect: SharedFlow<SignUpSideEffect> = _sideEffect.asSharedFlow()
+
+    fun signUp(
         email: String,
         password: String,
         passwordCheck: String
-    ): String? {
-        val errorType = SoptValidator.validateSignUpInputs(email, password, passwordCheck)
-        return errorType?.message
+    ) {
+        viewModelScope.launch {
+            val errorType = SoptValidator.validateSignUpInputs(email, password, passwordCheck)
+
+            if (errorType != null) {
+                _sideEffect.emit(SignUpSideEffect.ShowToast(errorType.message))
+            } else {
+                AuthPreference.saveAccount(email, password)
+                _sideEffect.emit(SignUpSideEffect.ShowToast("회원가입에 성공했습니다."))
+                _sideEffect.emit(SignUpSideEffect.NavigateToSignIn)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/signup/navigation/SignUpNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signup/navigation/SignUpNavigation.kt
@@ -1,0 +1,32 @@
+package com.example.letssopt.presentation.signup.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.example.letssopt.core.navigation.Route
+import com.example.letssopt.presentation.signup.SignUpRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigateSignUp(
+    navOptions: NavOptions? = null
+) {
+    navigate(SignUp, navOptions)
+}
+
+fun NavGraphBuilder.signUpGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit,
+) {
+    composable<SignUp> {
+        SignUpRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp,
+        )
+    }
+}
+
+
+@Serializable
+data object SignUp: Route

--- a/app/src/main/java/com/example/letssopt/presentation/signup/navigation/SignUpNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signup/navigation/SignUpNavigation.kt
@@ -22,7 +22,7 @@ fun NavGraphBuilder.signUpGraph(
     composable<SignUp> {
         SignUpRoute(
             paddingValues = paddingValues,
-            navigateUp = navigateUp,
+            navigateUp = navigateUp
         )
     }
 }

--- a/app/src/main/java/com/example/letssopt/presentation/signup/state/SignUpContract.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/signup/state/SignUpContract.kt
@@ -1,0 +1,6 @@
+package com.example.letssopt.presentation.signup.state
+
+sealed interface SignUpSideEffect {
+    data class ShowToast(val message: String) : SignUpSideEffect
+    data object NavigateToSignIn : SignUpSideEffect
+}

--- a/app/src/main/java/com/example/letssopt/presentation/webtoon/WebtoonScreen.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/webtoon/WebtoonScreen.kt
@@ -12,7 +12,8 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun WebtoonRoute(
-    paddingValues: PaddingValues
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
 ) {
     WebtoonScreen(
         paddingValues = paddingValues
@@ -20,7 +21,7 @@ fun WebtoonRoute(
 }
 
 @Composable
-fun WebtoonScreen(
+private fun WebtoonScreen(
     paddingValues: PaddingValues
 ) {
     Column (

--- a/app/src/main/java/com/example/letssopt/presentation/webtoon/navigation/WebtoonNavigation.kt
+++ b/app/src/main/java/com/example/letssopt/presentation/webtoon/navigation/WebtoonNavigation.kt
@@ -1,0 +1,32 @@
+package com.example.letssopt.presentation.webtoon.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.example.letssopt.core.navigation.MainTabRoute
+import com.example.letssopt.presentation.webtoon.WebtoonRoute
+import kotlinx.serialization.Serializable
+
+fun NavController.navigateWebtoon(
+    navOptions: NavOptions? = null
+) {
+    navigate(Webtoon, navOptions)
+}
+
+fun NavGraphBuilder.webtoonGraph(
+    paddingValues: PaddingValues,
+    navigateUp: () -> Unit
+) {
+    composable<Webtoon> {
+        WebtoonRoute(
+            paddingValues = paddingValues,
+            navigateUp = navigateUp
+        )
+    }
+}
+
+
+@Serializable
+data object Webtoon: MainTabRoute

--- a/app/src/main/res/drawable/ic_ticket.xml
+++ b/app/src/main/res/drawable/ic_ticket.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="18"
+    android:viewportHeight="18">
+  <path
+      android:pathData="M7.717,3.624V5.303"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="square"/>
+  <path
+      android:pathData="M7.717,12.996V14.4"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="square"/>
+  <path
+      android:pathData="M7.717,10.822V7.477"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="square"/>
+  <path
+      android:pathData="M2.063,14.55V10.492C2.899,10.492 3.573,9.827 3.573,9.001C3.573,8.175 2.899,7.509 2.063,7.509V3.45H15.938V7.567C15.101,7.567 14.427,8.175 14.427,9.001C14.427,9.827 15.101,10.492 15.938,10.492V14.55H2.063Z"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:fillType="evenOdd"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="square"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,5 @@
 <resources>
     <string name="app_name">LETSSOPT</string>
-    <string name="title_activity_sign_up">SignUpActivity</string>
-    <string name="title_activity_main">MainActivity</string>
-
 
     <string name="tab_main">메인</string>
     <string name="tab_purchase">개별 구매</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,35 +1,95 @@
 [versions]
+# Plugins
 agp = "8.13.2"
+ksp = "2.0.21-1.0.28"
+
+# Kotlin
 kotlin = "2.0.21"
 kotlinxImmutable = "0.4.0"
+kotlinxSerializationJson = "1.6.3"
+
+# AndroidX & Compose
 coreKtx = "1.17.0"
+lifecycle = "2.10.0"
+activityCompose = "1.12.3"
+composeBom = "2024.09.00"
+navigationCompose = "2.8.0"
+
+# Room
+room = "2.6.1"
+
+# Test
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.3"
-composeBom = "2024.09.00"
+
 
 [libraries]
+# Kotlinx
+kotlinx-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+
+# AndroidX Core
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+
+# Compose
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
-kotlinx-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+
+# Navigation
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# Room
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+
+# Test
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+
+
+[bundles]
+androidx-core = [
+    "androidx-core-ktx",
+    "androidx-lifecycle-runtime-ktx",
+    "androidx-lifecycle-viewmodel-compose",
+    "androidx-activity-compose"
+]
+compose = [
+    "androidx-compose-ui",
+    "androidx-compose-ui-graphics",
+    "androidx-compose-ui-tooling-preview",
+    "androidx-compose-material3"
+]
+compose-debug = [
+    "androidx-compose-ui-tooling",
+    "androidx-compose-ui-test-manifest"
+]
+room = [
+    "androidx-room-runtime",
+    "androidx-room-ktx"
+]
+androidTest = [
+    "androidx-junit",
+    "androidx-espresso-core",
+    "androidx-compose-ui-test-junit4"
+]
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## 📌 PR 요약

### 🧆 작업한 내용
필수 과제
- SAA 적용
- MVVM 적용

심화과제
- 개별구매 화면 구현 (LazyGrid 사용, 로컬 저장)

도약 과제
- 개별구매 화면에서 저장한 아이템을 보관함에서 보여주고 삭제기능 구현

### 🧆 PR 포인트
- SAA 구조 적용하면서 추가적으로 NavHost와 kotlinx.serialization을 활용하여 navigation 리팩토링 진행하였습니다.
- 구매 화면(PurchaseScreen)에서 아이템 추가 시, 
libraryDao.getItemById()를 호출하여 DB에 이미 존재하는 데이터인지 사전 검사하도록 했고, 
중복된 아이템일 경우 추가를 차단하고 "이미 보관함에 있는 작품입니다."라는 Toast 메시지가 발생하도록 방어 로직을 적용했습니다. 
- ViewModel에서 Toast 메시지 출력, 화면 이동과 같은 단발성 이벤트를 처리하기 위해 MutableSharedFlow 기반의 단방향 SideEffect 인터페이스를 적용했습니다.
- libs.versions.toml 파일에 흩어져 있던 라이브러리들을 역할에 맞게 [bundles] 블록(androidx-core, compose, room, androidTest 등)으로 묶어 모듈화했습니다.

## 📸 스크린샷
|                스크린샷                |
|:----------------------------------:|
| <video width="360" src="https://github.com/user-attachments/assets/691b671a-3ca6-4513-b652-1db38fe15874" /> |




## 📮 관련 이슈
- closed #6